### PR TITLE
Test vector framework

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -195,7 +195,7 @@ func (k *HPKEPublicKey) equals(o *HPKEPublicKey) bool {
 
 type HPKECiphertext struct {
 	KEMOutput  []byte `tls:"head=2"`
-	Ciphertext []byte `tls:"head=2"`
+	Ciphertext []byte `tls:"head=4"`
 }
 
 type hpkeInstance struct {
@@ -256,6 +256,12 @@ func (h hpkeInstance) Encrypt(pub HPKEPublicKey, aad, pt []byte) (HPKECiphertext
 }
 
 func (h hpkeInstance) Decrypt(priv HPKEPrivateKey, aad []byte, ct HPKECiphertext) ([]byte, error) {
+	fmt.Printf("=== HPKE Decrypt ===\n")
+	fmt.Printf("priv: %x\n", priv.Data)
+	fmt.Printf("aad:  %x\n", aad)
+	fmt.Printf("ct.k: %x\n", ct.KEMOutput)
+	fmt.Printf("ct.c: %x\n", ct.Ciphertext)
+
 	skR, err := h.Suite.KEM.UnmarshalPrivate(priv.Data)
 	if err != nil {
 		return nil, err

--- a/test-vectors_test.go
+++ b/test-vectors_test.go
@@ -41,6 +41,12 @@ var testVectorCases = map[string]TestVectorCase{
 		Verify:   verifyTreeMathVectors,
 	},
 
+	"crypto": {
+		Filename: "crypto.bin",
+		Generate: generateCryptoVectors,
+		Verify:   verifyCryptoVectors,
+	},
+
 	// TODO continue
 }
 

--- a/test-vectors_test.go
+++ b/test-vectors_test.go
@@ -1,0 +1,93 @@
+package mls
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// To generate or verify test vectors, run `go test` with these environment
+// variables set to point to the directory where the test files reside.  The
+// names of the individual files of test vectors are specified in the test
+// vector cases below.
+//
+// > MLS_TEST_VECTORS_OUT=... go test -run VectorGen
+// > MLS_TEST_VECTORS_IN=...  go test -run VectorVer
+const (
+	testDirWriteEnv = "MLS_TEST_VECTORS_OUT"
+	testDirReadEnv  = "MLS_TEST_VECTORS_IN"
+)
+
+// For each set of test vectors, this struct defines:
+//
+// * The file name with which the vectors should be saved / loaded
+// * A function to generate test vectors
+// * A function to verify test vectors
+//
+// The generate and verify functions are responsible for reporting their own
+// errors through the testing.T object passed to them.  The functions themselves
+// should be defined in the test files for the relevant modules.
+type TestVectorCase struct {
+	Filename string
+	Generate func(t *testing.T) []byte
+	Verify   func(t *testing.T, data []byte)
+}
+
+var testVectorCases = map[string]TestVectorCase{
+	"tree_math": {
+		Filename: "tree_math.bin",
+		Generate: generateTreeMathVectors,
+		Verify:   verifyTreeMathVectors,
+	},
+
+	// TODO continue
+}
+
+func vectorGenerate(c TestVectorCase, testDir string) func(t *testing.T) {
+	return func(t *testing.T) {
+		// Generate test vectors
+		vec := c.Generate(t)
+
+		// Verify that vectors pass
+		c.Verify(t, vec)
+
+		// Write the vectors to file if required
+		if len(testDir) != 0 {
+			file := filepath.Join(testDir, c.Filename)
+			err := ioutil.WriteFile(file, vec, 0644)
+			assertNotError(t, err, "Error writing test vectors")
+		}
+	}
+}
+
+func TestVectorGenerate(t *testing.T) {
+	testDir := os.Getenv(testDirWriteEnv)
+
+	for label, tvCase := range testVectorCases {
+		t.Run(label, vectorGenerate(tvCase, testDir))
+	}
+}
+
+func vectorVerify(c TestVectorCase, testDir string) func(t *testing.T) {
+	return func(t *testing.T) {
+		// Read test vectors
+		file := filepath.Join(testDir, c.Filename)
+		vec, err := ioutil.ReadFile(file)
+		assertNotError(t, err, "Error reading test vectors")
+
+		// Verify test vectors
+		c.Verify(t, vec)
+	}
+}
+
+func TestVectorVerify(t *testing.T) {
+	testDir := ""
+	if testDir = os.Getenv(testDirReadEnv); len(testDir) == 0 {
+		t.Skip("Test vectors were not provided")
+	}
+
+	for label, tvCase := range testVectorCases {
+		t.Run(label, vectorVerify(tvCase, testDir))
+	}
+}

--- a/tree-math_test.go
+++ b/tree-math_test.go
@@ -131,7 +131,7 @@ func generateTreeMathVectors(t *testing.T) []byte {
 	numNodes := nodeWidth(numLeaves)
 	tv := TreeMathTestVectors{
 		NumLeaves: numLeaves,
-		Root:      make([]nodeIndex, numNodes),
+		Root:      make([]nodeIndex, numLeaves),
 		Left:      make([]nodeIndex, numNodes),
 		Right:     make([]nodeIndex, numNodes),
 		Parent:    make([]nodeIndex, numNodes),
@@ -139,7 +139,10 @@ func generateTreeMathVectors(t *testing.T) []byte {
 	}
 
 	for i := range tv.Root {
-		tv.Root[i] = root(leafCount(i))
+		tv.Root[i] = root(leafCount(i + 1))
+	}
+
+	for i := range tv.Left {
 		tv.Left[i] = left(nodeIndex(i))
 		tv.Right[i] = right(nodeIndex(i), numLeaves)
 		tv.Parent[i] = parent(nodeIndex(i), numLeaves)
@@ -157,12 +160,16 @@ func verifyTreeMathVectors(t *testing.T, data []byte) {
 	assertNotError(t, err, "Malformed tree math test vectors")
 
 	tvLen := int(nodeWidth(tv.NumLeaves))
-	if len(tv.Root) != tvLen || len(tv.Left) != tvLen || len(tv.Right) != tvLen || len(tv.Parent) != tvLen || len(tv.Sibling) != tvLen {
-		t.Fatalf("Malformed tree math test vectors")
+	if len(tv.Root) != int(tv.NumLeaves) || len(tv.Left) != tvLen ||
+		len(tv.Right) != tvLen || len(tv.Parent) != tvLen || len(tv.Sibling) != tvLen {
+		t.Fatalf("Malformed tree math test vectors: Incorrect vector sizes")
 	}
 
 	for i := range tv.Root {
-		assertEquals(t, tv.Root[i], root(leafCount(i)))
+		assertEquals(t, tv.Root[i], root(leafCount(i+1)))
+	}
+
+	for i := range tv.Left {
 		assertEquals(t, tv.Left[i], left(nodeIndex(i)))
 		assertEquals(t, tv.Right[i], right(nodeIndex(i), tv.NumLeaves))
 		assertEquals(t, tv.Parent[i], parent(nodeIndex(i), tv.NumLeaves))

--- a/tree-math_test.go
+++ b/tree-math_test.go
@@ -110,3 +110,17 @@ func TestPaths(t *testing.T) {
 	run("dirpath", dirpath, aDirpath)
 	run("copath", copath, aCopath)
 }
+
+///
+/// Test Vectors
+///
+
+func generateTreeMathVectors(t *testing.T) []byte {
+	// TODO
+	return nil
+}
+
+func verifyTreeMathVectors(t *testing.T, data []byte) {
+	// TODO
+	return
+}

--- a/tree-math_test.go
+++ b/tree-math_test.go
@@ -3,6 +3,8 @@ package mls
 import (
 	"reflect"
 	"testing"
+
+	"github.com/bifurcation/mint/syntax"
 )
 
 // Precomputed answers for the tree on ten elements:
@@ -115,12 +117,55 @@ func TestPaths(t *testing.T) {
 /// Test Vectors
 ///
 
+type TreeMathTestVectors struct {
+	NumLeaves leafCount
+	Root      []nodeIndex `tls:"head=4"`
+	Left      []nodeIndex `tls:"head=4"`
+	Right     []nodeIndex `tls:"head=4"`
+	Parent    []nodeIndex `tls:"head=4"`
+	Sibling   []nodeIndex `tls:"head=4"`
+}
+
 func generateTreeMathVectors(t *testing.T) []byte {
-	// TODO
-	return nil
+	numLeaves := leafCount(255)
+	numNodes := nodeWidth(numLeaves)
+	tv := TreeMathTestVectors{
+		NumLeaves: numLeaves,
+		Root:      make([]nodeIndex, numNodes),
+		Left:      make([]nodeIndex, numNodes),
+		Right:     make([]nodeIndex, numNodes),
+		Parent:    make([]nodeIndex, numNodes),
+		Sibling:   make([]nodeIndex, numNodes),
+	}
+
+	for i := range tv.Root {
+		tv.Root[i] = root(leafCount(i))
+		tv.Left[i] = left(nodeIndex(i))
+		tv.Right[i] = right(nodeIndex(i), numLeaves)
+		tv.Parent[i] = parent(nodeIndex(i), numLeaves)
+		tv.Sibling[i] = sibling(nodeIndex(i), numLeaves)
+	}
+
+	vec, err := syntax.Marshal(tv)
+	assertNotError(t, err, "Error marshaling test vectors")
+	return vec
 }
 
 func verifyTreeMathVectors(t *testing.T, data []byte) {
-	// TODO
-	return
+	var tv TreeMathTestVectors
+	_, err := syntax.Unmarshal(data, &tv)
+	assertNotError(t, err, "Malformed tree math test vectors")
+
+	tvLen := int(nodeWidth(tv.NumLeaves))
+	if len(tv.Root) != tvLen || len(tv.Left) != tvLen || len(tv.Right) != tvLen || len(tv.Parent) != tvLen || len(tv.Sibling) != tvLen {
+		t.Fatalf("Malformed tree math test vectors")
+	}
+
+	for i := range tv.Root {
+		assertEquals(t, tv.Root[i], root(leafCount(i)))
+		assertEquals(t, tv.Left[i], left(nodeIndex(i)))
+		assertEquals(t, tv.Right[i], right(nodeIndex(i), tv.NumLeaves))
+		assertEquals(t, tv.Parent[i], parent(nodeIndex(i), tv.NumLeaves))
+		assertEquals(t, tv.Sibling[i], sibling(nodeIndex(i), tv.NumLeaves))
+	}
 }


### PR DESCRIPTION
This PR adds a framework for running tests over test vector files, as a way of [verifying interop with other MLS implementations](https://github.com/mlswg/mls-implementations/tree/master/test_vectors).  Right now, it only adds:

* A general framework for reading and writing test vectors
* Test vector code for tree math tests

Other test vectors should be straightforward to add from this baseline.