### PR TITLE
Epoch secret in welcome

### DIFF
--- a/key-schedule.go
+++ b/key-schedule.go
@@ -236,32 +236,22 @@ func (gks groupKeySource) Erase(sender leafIndex, generation uint32) {
 }
 
 ///
-/// First epoch
+/// GroupInfo keys
 ///
 
-type firstEpoch struct {
-	Suite           CipherSuite
-	InitSecret      []byte
-	GroupInfoSecret []byte
-	GroupInfoKey    []byte
-	GroupInfoNonce  []byte
-}
-
-func newFirstEpoch(suite CipherSuite, initSecret []byte) *firstEpoch {
+func groupInfoKeyAndNonce(suite CipherSuite, epochSecret []byte) keyAndNonce {
 	secretSize := suite.constants().SecretSize
 	keySize := suite.constants().KeySize
 	nonceSize := suite.constants().NonceSize
 
-	groupInfoSecret := suite.hkdfExpandLabel(initSecret, "group info", []byte{}, secretSize)
+	groupInfoSecret := suite.hkdfExpandLabel(epochSecret, "group info", []byte{}, secretSize)
 	groupInfoKey := suite.hkdfExpandLabel(groupInfoSecret, "key", []byte{}, keySize)
 	groupInfoNonce := suite.hkdfExpandLabel(groupInfoSecret, "nonce", []byte{}, nonceSize)
 
-	return &firstEpoch{suite, initSecret, groupInfoSecret, groupInfoKey, groupInfoNonce}
-}
-
-func (fe firstEpoch) Next(size leafCount, updateSecret, context []byte) keyScheduleEpoch {
-	epochSecret := fe.Suite.hkdfExtract(fe.InitSecret, updateSecret)
-	return newKeyScheduleEpoch(fe.Suite, size, epochSecret, context)
+	return keyAndNonce{
+		Key:   groupInfoKey,
+		Nonce: groupInfoNonce,
+	}
 }
 
 ///

--- a/key-schedule_test.go
+++ b/key-schedule_test.go
@@ -29,10 +29,8 @@ func TestKeySchedule(t *testing.T) {
 	keySize := suite.constants().KeySize
 	nonceSize := suite.constants().NonceSize
 
-	initSecret := unhex("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
-
 	size1 := leafCount(5)
-	commitSecret1 := unhex("202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f")
+	epochSecret1 := unhex("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
 	context1 := []byte("first")
 
 	size2 := leafCount(11)
@@ -40,16 +38,6 @@ func TestKeySchedule(t *testing.T) {
 	context2 := []byte("second")
 
 	targetGeneration := uint32(3)
-
-	epoch0 := newFirstEpoch(suite, initSecret)
-	ok0 := (epoch0.Suite == suite) &&
-		bytes.Equal(epoch0.InitSecret, initSecret) &&
-		(len(epoch0.GroupInfoSecret) == secretSize) &&
-		(len(epoch0.GroupInfoKey) == keySize) &&
-		(len(epoch0.GroupInfoNonce) == nonceSize)
-	if !ok0 {
-		t.Fatalf("Malformed first epoch")
-	}
 
 	checkEpoch := func(epoch keyScheduleEpoch, size leafCount) {
 		ok := (epoch.Suite == suite) &&
@@ -85,7 +73,7 @@ func TestKeySchedule(t *testing.T) {
 		}
 	}
 
-	epoch1 := epoch0.Next(size1, commitSecret1, context1)
+	epoch1 := newKeyScheduleEpoch(suite, size1, epochSecret1, context1)
 	checkEpoch(epoch1, size1)
 
 	epoch2 := epoch1.Next(size2, commitSecret2, context2)

--- a/messages.go
+++ b/messages.go
@@ -453,25 +453,22 @@ type MLSCiphertext struct {
 ///
 
 type GroupInfo struct {
-	GroupId                      []byte `tls:"head=1"`
-	Epoch                        Epoch
-	Tree                         RatchetTree
-	PriorConfirmedTranscriptHash []byte `tls:"head=1"`
-	ConfirmedTranscriptHash      []byte `tls:"head=1"`
-	InterimTranscriptHash        []byte `tls:"head=1"`
-	Path                         DirectPath
-	Confirmation                 []byte `tls:"head=1"`
-	SignerIndex                  leafIndex
-	Signature                    []byte `tls:"head=2"`
+	GroupID                 []byte `tls:"head=1"`
+	Epoch                   Epoch
+	Tree                    RatchetTree
+	ConfirmedTranscriptHash []byte `tls:"head=1"`
+	InterimTranscriptHash   []byte `tls:"head=1"`
+	Confirmation            []byte `tls:"head=1"`
+	SignerIndex             leafIndex
+	Signature               []byte `tls:"head=2"`
 }
 
 func (gi GroupInfo) dump() {
 	fmt.Printf("\n+++++ groupInfo +++++\n")
-	fmt.Printf("\tGroupId %x, Epoch %x\n", gi.GroupId, gi.Epoch)
+	fmt.Printf("\tGroupID %x, Epoch %x\n", gi.GroupID, gi.Epoch)
 	gi.Tree.Dump("Tree")
-	fmt.Printf("\tPriorConfirmedTranscriptHash %x, ConfirmedTranscriptHash %x, InterimTranscriptHash %x\n",
-		gi.PriorConfirmedTranscriptHash, gi.ConfirmedTranscriptHash, gi.InterimTranscriptHash)
-	gi.Path.dump()
+	fmt.Printf("ConfirmedTranscriptHash %x, InterimTranscriptHash %x\n",
+		gi.ConfirmedTranscriptHash, gi.InterimTranscriptHash)
 	fmt.Printf("\tConfirmation %x, SignerIndex %x\n", gi.Confirmation, gi.SignerIndex)
 	fmt.Printf("\tSignature %x\n", gi.Signature)
 	fmt.Printf("\n+++++ groupInfo +++++\n")
@@ -479,21 +476,19 @@ func (gi GroupInfo) dump() {
 
 func (gi GroupInfo) toBeSigned() ([]byte, error) {
 	return syntax.Marshal(struct {
-		GroupId                 []byte `tls:"head=1"`
+		GroupID                 []byte `tls:"head=1"`
 		Epoch                   Epoch
 		Tree                    RatchetTree
 		ConfirmedTranscriptHash []byte `tls:"head=1"`
 		InterimTranscriptHash   []byte `tls:"head=1"`
-		Path                    DirectPath
 		Confirmation            []byte `tls:"head=1"`
 		SignerIndex             leafIndex
 	}{
-		GroupId:                 gi.GroupId,
+		GroupID:                 gi.GroupID,
 		Epoch:                   gi.Epoch,
 		Tree:                    gi.Tree,
 		ConfirmedTranscriptHash: gi.ConfirmedTranscriptHash,
 		InterimTranscriptHash:   gi.InterimTranscriptHash,
-		Path:                    gi.Path,
 		Confirmation:            gi.Confirmation,
 		SignerIndex:             gi.SignerIndex,
 	})
@@ -540,14 +535,6 @@ func (gi GroupInfo) verify() error {
 	}
 
 	return nil
-}
-
-func newGroupInfo(gid []byte, epoch Epoch, transriptHash []byte) *GroupInfo {
-	gi := new(GroupInfo)
-	gi.GroupId = gid
-	gi.Epoch = epoch
-	gi.PriorConfirmedTranscriptHash = transriptHash
-	return gi
 }
 
 ///

--- a/messages_test.go
+++ b/messages_test.go
@@ -195,17 +195,18 @@ func TestWelcomeMarshalUnMarshalWithDecryption(t *testing.T) {
 	gi := &GroupInfo{
 		GroupId:                      unhex("0007"),
 		Epoch:                        121,
-		Tree:                         treeAB,
+		Tree:                         *treeAB,
 		PriorConfirmedTranscriptHash: []byte{0x00, 0x01, 0x02, 0x03},
 		ConfirmedTranscriptHash:      []byte{0x03, 0x04, 0x05, 0x06},
 		InterimTranscriptHash:        []byte{0x02, 0x03, 0x04, 0x05},
-		Path:                         dp,
+		Path:                         *dp,
 		SignerIndex:                  0,
 		Confirmation:                 []byte{0x00, 0x00, 0x00, 0x00},
 		Signature:                    []byte{0xAA, 0xBB, 0xCC},
 	}
 
-	w1 := newWelcome(cs, epochSecret, gi, []ClientInitKey{*clientInitKey})
+	w1 := newWelcome(cs, epochSecret, gi)
+	w1.EncryptTo(*clientInitKey, secret)
 	// doing this so that test can omit this field when matching w1, w2
 	w1.epochSecret = nil
 	w2 := new(Welcome)
@@ -261,7 +262,7 @@ type MessageTestVectors struct {
 func groupInfoMatch(t *testing.T, l, r GroupInfo) {
 	assertByteEquals(t, l.GroupId, r.GroupId)
 	assertEquals(t, l.Epoch, r.Epoch)
-	assertTrue(t, l.Tree.Equals(r.Tree), "tree unequal")
+	assertTrue(t, l.Tree.Equals(&r.Tree), "tree unequal")
 	assertByteEquals(t, l.PriorConfirmedTranscriptHash, r.PriorConfirmedTranscriptHash)
 	assertByteEquals(t, l.ConfirmedTranscriptHash, r.ConfirmedTranscriptHash)
 	assertByteEquals(t, l.InterimTranscriptHash, r.InterimTranscriptHash)
@@ -338,9 +339,10 @@ func generateMessageVectors(t *testing.T) []byte {
 
 		// Welcome
 
-		gi := newGroupInfo(tv.GroupId, tv.Epoch, *ratchetTree, tv.Random)
+		gi := newGroupInfo(tv.GroupId, tv.Epoch, tv.Random)
+		gi.Tree = *ratchetTree
 		gi.SignerIndex = tv.SingerIndex
-		gi.Path = dp
+		gi.Path = *dp
 		gi.ConfirmedTranscriptHash = tv.Random
 		gi.InterimTranscriptHash = tv.Random
 		gi.Confirmation = tv.Random
@@ -525,9 +527,10 @@ func verifyMessageVectors(t *testing.T, data []byte) {
 		assertByteEquals(t, cikM, tc.ClientInitKey)
 
 		// Welcome
-		gi := newGroupInfo(tv.GroupId, tv.Epoch, *ratchetTree, tv.Random)
+		gi := newGroupInfo(tv.GroupId, tv.Epoch, tv.Random)
+		gi.Tree = *ratchetTree
 		gi.SignerIndex = tv.SingerIndex
-		gi.Path = dp
+		gi.Path = *dp
 		gi.ConfirmedTranscriptHash = tv.Random
 		gi.InterimTranscriptHash = tv.Random
 		gi.Confirmation = tv.Random

--- a/messages_test.go
+++ b/messages_test.go
@@ -191,7 +191,7 @@ func TestWelcomeMarshalUnMarshalWithDecryption(t *testing.T) {
 	dp, _ := treeAB.Encap(leafIndex(0), []byte{}, secret)
 
 	// setup things needed to welcome c
-	initSecret := []byte("we welcome you c")
+	epochSecret := []byte("we welcome you c")
 	gi := &GroupInfo{
 		GroupId:                      unhex("0007"),
 		Epoch:                        121,
@@ -205,9 +205,9 @@ func TestWelcomeMarshalUnMarshalWithDecryption(t *testing.T) {
 		Signature:                    []byte{0xAA, 0xBB, 0xCC},
 	}
 
-	w1 := newWelcome(cs, initSecret, gi, []ClientInitKey{*clientInitKey})
+	w1 := newWelcome(cs, epochSecret, gi, []ClientInitKey{*clientInitKey})
 	// doing this so that test can omit this field when matching w1, w2
-	w1.initSecret = nil
+	w1.epochSecret = nil
 	w2 := new(Welcome)
 	t.Run("WelcomeOneMember", roundTrip(w1, w2))
 
@@ -220,7 +220,7 @@ func TestWelcomeMarshalUnMarshalWithDecryption(t *testing.T) {
 	w2kp := new(KeyPackage)
 	_, err = syntax.Unmarshal(pt, w2kp)
 	assertNotError(t, err, "unmarshal failure for decrypted KeyPackage")
-	assertByteEquals(t, initSecret, w2kp.InitSecret)
+	assertByteEquals(t, epochSecret, w2kp.EpochSecret)
 }
 
 ///
@@ -350,7 +350,7 @@ func generateMessageVectors(t *testing.T) []byte {
 		assertNotError(t, err, "grpInfo marshal")
 
 		kp := KeyPackage{
-			InitSecret: tv.Random,
+			EpochSecret: tv.Random,
 		}
 
 		kpM, err := syntax.Marshal(kp)
@@ -540,7 +540,7 @@ func verifyMessageVectors(t *testing.T, data []byte) {
 		groupInfoMatch(t, *gi, giWire)
 
 		kp := KeyPackage{
-			InitSecret: tv.Random,
+			EpochSecret: tv.Random,
 		}
 
 		kpM, err := syntax.Marshal(kp)

--- a/messages_test.go
+++ b/messages_test.go
@@ -188,21 +188,18 @@ func TestWelcomeMarshalUnMarshalWithDecryption(t *testing.T) {
 
 	cs := supportedSuites[0]
 	secret, _ := getRandomBytes(32)
-	dp, _ := treeAB.Encap(leafIndex(0), []byte{}, secret)
 
 	// setup things needed to welcome c
 	epochSecret := []byte("we welcome you c")
 	gi := &GroupInfo{
-		GroupId:                      unhex("0007"),
-		Epoch:                        121,
-		Tree:                         *treeAB,
-		PriorConfirmedTranscriptHash: []byte{0x00, 0x01, 0x02, 0x03},
-		ConfirmedTranscriptHash:      []byte{0x03, 0x04, 0x05, 0x06},
-		InterimTranscriptHash:        []byte{0x02, 0x03, 0x04, 0x05},
-		Path:                         *dp,
-		SignerIndex:                  0,
-		Confirmation:                 []byte{0x00, 0x00, 0x00, 0x00},
-		Signature:                    []byte{0xAA, 0xBB, 0xCC},
+		GroupID:                 unhex("0007"),
+		Epoch:                   121,
+		Tree:                    *treeAB,
+		ConfirmedTranscriptHash: []byte{0x03, 0x04, 0x05, 0x06},
+		InterimTranscriptHash:   []byte{0x02, 0x03, 0x04, 0x05},
+		SignerIndex:             0,
+		Confirmation:            []byte{0x00, 0x00, 0x00, 0x00},
+		Signature:               []byte{0xAA, 0xBB, 0xCC},
 	}
 
 	w1 := newWelcome(cs, epochSecret, gi)
@@ -246,10 +243,10 @@ type MessageTestCase struct {
 
 type MessageTestVectors struct {
 	Epoch           Epoch
-	SingerIndex     leafIndex
+	SignerIndex     leafIndex
 	Removed         leafIndex
 	UserId          []byte            `tls:"head=1"`
-	GroupId         []byte            `tls:"head=1"`
+	GroupID         []byte            `tls:"head=1"`
 	ClientInitKeyId []byte            `tls:"head=1"`
 	DHSeed          []byte            `tls:"head=1"`
 	SigSeed         []byte            `tls:"head=1"`
@@ -260,10 +257,9 @@ type MessageTestVectors struct {
 //helpers
 
 func groupInfoMatch(t *testing.T, l, r GroupInfo) {
-	assertByteEquals(t, l.GroupId, r.GroupId)
+	assertByteEquals(t, l.GroupID, r.GroupID)
 	assertEquals(t, l.Epoch, r.Epoch)
 	assertTrue(t, l.Tree.Equals(&r.Tree), "tree unequal")
-	assertByteEquals(t, l.PriorConfirmedTranscriptHash, r.PriorConfirmedTranscriptHash)
 	assertByteEquals(t, l.ConfirmedTranscriptHash, r.ConfirmedTranscriptHash)
 	assertByteEquals(t, l.InterimTranscriptHash, r.InterimTranscriptHash)
 	assertByteEquals(t, l.Confirmation, r.Confirmation)
@@ -282,10 +278,10 @@ func commitMatch(t *testing.T, l, r Commit) {
 func generateMessageVectors(t *testing.T) []byte {
 	tv := MessageTestVectors{
 		Epoch:           0xA0A1A2A3,
-		SingerIndex:     leafIndex(0xB0B1B2B3),
+		SignerIndex:     leafIndex(0xB0B1B2B3),
 		Removed:         leafIndex(0xC0C1C2C3),
 		UserId:          bytes.Repeat([]byte{0xD1}, 16),
-		GroupId:         bytes.Repeat([]byte{0xD2}, 16),
+		GroupID:         bytes.Repeat([]byte{0xD2}, 16),
 		ClientInitKeyId: bytes.Repeat([]byte{0xD3}, 16),
 		DHSeed:          bytes.Repeat([]byte{0xD4}, 32),
 		SigSeed:         bytes.Repeat([]byte{0xD5}, 32),
@@ -339,14 +335,16 @@ func generateMessageVectors(t *testing.T) []byte {
 
 		// Welcome
 
-		gi := newGroupInfo(tv.GroupId, tv.Epoch, tv.Random)
-		gi.Tree = *ratchetTree
-		gi.SignerIndex = tv.SingerIndex
-		gi.Path = *dp
-		gi.ConfirmedTranscriptHash = tv.Random
-		gi.InterimTranscriptHash = tv.Random
-		gi.Confirmation = tv.Random
-		gi.Signature = tv.Random
+		gi := &GroupInfo{
+			GroupID:                 tv.GroupID,
+			Epoch:                   tv.Epoch,
+			Tree:                    *ratchetTree,
+			ConfirmedTranscriptHash: tv.Random,
+			InterimTranscriptHash:   tv.Random,
+			Confirmation:            tv.Random,
+			SignerIndex:             tv.SignerIndex,
+			Signature:               tv.Random,
+		}
 
 		giM, err := syntax.Marshal(gi)
 		assertNotError(t, err, "grpInfo marshal")
@@ -385,9 +383,9 @@ func generateMessageVectors(t *testing.T) []byte {
 		}
 
 		addHs := MLSPlaintext{
-			GroupID: tv.GroupId,
+			GroupID: tv.GroupID,
 			Epoch:   tv.Epoch,
-			Sender:  tv.SingerIndex,
+			Sender:  tv.SignerIndex,
 			Content: MLSPlaintextContent{
 				Proposal: addProposal,
 			},
@@ -404,9 +402,9 @@ func generateMessageVectors(t *testing.T) []byte {
 		}
 
 		updateHs := MLSPlaintext{
-			GroupID: tv.GroupId,
+			GroupID: tv.GroupID,
 			Epoch:   tv.Epoch,
-			Sender:  tv.SingerIndex,
+			Sender:  tv.SignerIndex,
 			Content: MLSPlaintextContent{
 				Proposal: updateProposal,
 			},
@@ -418,14 +416,14 @@ func generateMessageVectors(t *testing.T) []byte {
 
 		removeProposal := &Proposal{
 			Remove: &RemoveProposal{
-				Removed: tv.SingerIndex,
+				Removed: tv.SignerIndex,
 			},
 		}
 
 		removeHs := MLSPlaintext{
-			GroupID: tv.GroupId,
+			GroupID: tv.GroupID,
 			Epoch:   tv.Epoch,
-			Sender:  tv.SingerIndex,
+			Sender:  tv.SignerIndex,
 			Content: MLSPlaintextContent{
 				Proposal: removeProposal,
 			},
@@ -442,6 +440,7 @@ func generateMessageVectors(t *testing.T) []byte {
 			Removes: proposal,
 			Adds:    proposal,
 			Ignored: proposal,
+			Path:    *dp,
 		}
 
 		commitM, err := syntax.Marshal(commit)
@@ -449,7 +448,7 @@ func generateMessageVectors(t *testing.T) []byte {
 
 		//MlsCiphertext
 		ct := MLSCiphertext{
-			GroupID:             tv.GroupId,
+			GroupID:             tv.GroupID,
 			Epoch:               tv.Epoch,
 			ContentType:         ContentTypeApplication,
 			SenderDataNonce:     tv.Random,
@@ -527,14 +526,16 @@ func verifyMessageVectors(t *testing.T, data []byte) {
 		assertByteEquals(t, cikM, tc.ClientInitKey)
 
 		// Welcome
-		gi := newGroupInfo(tv.GroupId, tv.Epoch, tv.Random)
-		gi.Tree = *ratchetTree
-		gi.SignerIndex = tv.SingerIndex
-		gi.Path = *dp
-		gi.ConfirmedTranscriptHash = tv.Random
-		gi.InterimTranscriptHash = tv.Random
-		gi.Confirmation = tv.Random
-		gi.Signature = tv.Random
+		gi := &GroupInfo{
+			GroupID:                 tv.GroupID,
+			Epoch:                   tv.Epoch,
+			Tree:                    *ratchetTree,
+			ConfirmedTranscriptHash: tv.Random,
+			InterimTranscriptHash:   tv.Random,
+			Confirmation:            tv.Random,
+			SignerIndex:             tv.SignerIndex,
+			Signature:               tv.Random,
+		}
 
 		var giWire GroupInfo
 		_, err = syntax.Unmarshal(tc.GroupInfo, &giWire)
@@ -580,9 +581,9 @@ func verifyMessageVectors(t *testing.T, data []byte) {
 		}
 
 		addHs := MLSPlaintext{
-			GroupID: tv.GroupId,
+			GroupID: tv.GroupID,
 			Epoch:   tv.Epoch,
-			Sender:  tv.SingerIndex,
+			Sender:  tv.SignerIndex,
 			Content: MLSPlaintextContent{
 				Proposal: addProposal,
 			},
@@ -600,9 +601,9 @@ func verifyMessageVectors(t *testing.T, data []byte) {
 		}
 
 		updateHs := MLSPlaintext{
-			GroupID: tv.GroupId,
+			GroupID: tv.GroupID,
 			Epoch:   tv.Epoch,
-			Sender:  tv.SingerIndex,
+			Sender:  tv.SignerIndex,
 			Content: MLSPlaintextContent{
 				Proposal: updateProposal,
 			},
@@ -615,14 +616,14 @@ func verifyMessageVectors(t *testing.T, data []byte) {
 
 		removeProposal := &Proposal{
 			Remove: &RemoveProposal{
-				Removed: tv.SingerIndex,
+				Removed: tv.SignerIndex,
 			},
 		}
 
 		removeHs := MLSPlaintext{
-			GroupID: tv.GroupId,
+			GroupID: tv.GroupID,
 			Epoch:   tv.Epoch,
-			Sender:  tv.SingerIndex,
+			Sender:  tv.SignerIndex,
 			Content: MLSPlaintextContent{
 				Proposal: removeProposal,
 			},
@@ -648,7 +649,7 @@ func verifyMessageVectors(t *testing.T, data []byte) {
 
 		//MlsCiphertext
 		ct := MLSCiphertext{
-			GroupID:             tv.GroupId,
+			GroupID:             tv.GroupID,
 			Epoch:               tv.Epoch,
 			ContentType:         ContentTypeApplication,
 			SenderDataNonce:     tv.Random,

--- a/ratchet-tree.go
+++ b/ratchet-tree.go
@@ -433,7 +433,13 @@ func (t *RatchetTree) Decap(from leafIndex, context []byte, path *DirectPath) ([
 		return nil, err
 	}
 
-	return t.Implant(overlap, pathSecret)
+	rootSecret, err := t.Implant(overlap, pathSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	t.setHashPath(from)
+	return rootSecret, nil
 }
 
 func (t *RatchetTree) Merge(index leafIndex, secret []byte) error {

--- a/ratchet-tree_test.go
+++ b/ratchet-tree_test.go
@@ -251,7 +251,9 @@ func TestRatchetTreeEncryptDecrypt(t *testing.T) {
 			if i == j {
 				continue
 			}
-			decryptedSecret := dstTree.Decap(leafIndex(i), []byte{}, path)
+
+			decryptedSecret, err := dstTree.Decap(leafIndex(i), []byte{}, path)
+			assertNotError(t, err, "Error in decap()")
 			assertByteEquals(t, rootSecret, decryptedSecret)
 			assertTrue(t, srcTree.Equals(dstTree), "Failed update on decap()")
 		}

--- a/state.go
+++ b/state.go
@@ -173,9 +173,9 @@ func newJoinedState(ciks []ClientInitKey, welcome Welcome) (*State, error) {
 		gi.PriorConfirmedTranscriptHash,
 	})
 
-	updateSecret := s.Tree.Decap(gi.SignerIndex, decapCtx, gi.Path)
-	if updateSecret == nil {
-		return nil, fmt.Errorf("mls.state: decrypting root secret got nil value")
+	_, err = s.Tree.Decap(gi.SignerIndex, decapCtx, gi.Path)
+	if err != nil {
+		return nil, err
 	}
 
 	encGrpCtx, err := syntax.Marshal(s.groupContext())
@@ -580,7 +580,10 @@ func (s *State) handle(pt *MLSPlaintext) (*State, error) {
 		return nil, fmt.Errorf("mls.state: failure to create context %v", err)
 	}
 
-	updateSecret := next.Tree.Decap(pt.Sender, ctx, &commitData.Commit.Path)
+	updateSecret, err := next.Tree.Decap(pt.Sender, ctx, &commitData.Commit.Path)
+	if err != nil {
+		return nil, err
+	}
 
 	// Update the transcripts and advance the key schedule
 	digest := next.CipherSuite.newDigest()

--- a/tree-math.go
+++ b/tree-math.go
@@ -163,3 +163,16 @@ func copath(x nodeIndex, n leafCount) []nodeIndex {
 
 	return c
 }
+
+// Common ancestor of two leaves
+func ancestor(l, r leafIndex) nodeIndex {
+	ln, rn := toNodeIndex(l), toNodeIndex(r)
+
+	k := uint(0)
+	for ln != rn {
+		ln, rn = ln>>1, rn>>1
+		k += 1
+	}
+
+	return (ln << k) + (1 << (k - 1)) - 1
+}

--- a/tree-math_test.go
+++ b/tree-math_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/bifurcation/mint/syntax"
 )
 
-// Precomputed answers for the tree on ten elements:
+// Precomputed answers for the tree on eleven elements:
 //
 //                                              X
 //                      X
@@ -73,6 +73,19 @@ var (
 		{0x07},
 		{0x11, 0x07},
 	}
+
+	aAncestor = [][]nodeIndex{
+		{0x01, 0x03, 0x03, 0x07, 0x07, 0x07, 0x07, 0x0f, 0x0f, 0x0f},
+		{0x03, 0x03, 0x07, 0x07, 0x07, 0x07, 0x0f, 0x0f, 0x0f},
+		{0x05, 0x07, 0x07, 0x07, 0x07, 0x0f, 0x0f, 0x0f},
+		{0x07, 0x07, 0x07, 0x07, 0x0f, 0x0f, 0x0f},
+		{0x09, 0x0b, 0x0b, 0x0f, 0x0f, 0x0f},
+		{0x0b, 0x0b, 0x0f, 0x0f, 0x0f},
+		{0x0d, 0x0f, 0x0f, 0x0f},
+		{0x0f, 0x0f, 0x0f},
+		{0x11, 0x13},
+		{0x13},
+	}
 )
 
 func TestSizeProperties(t *testing.T) {
@@ -111,6 +124,24 @@ func TestPaths(t *testing.T) {
 
 	run("dirpath", dirpath, aDirpath)
 	run("copath", copath, aCopath)
+}
+
+func TestAncestor(t *testing.T) {
+	for l := leafIndex(0); l < leafIndex(aN-1); l += 1 {
+		for r := l + 1; r < leafIndex(aN); r += 1 {
+			answer := aAncestor[l][r-l-1]
+			lr := ancestor(l, r)
+			rl := ancestor(r, l)
+
+			if lr != answer {
+				t.Fatalf("Incorrect ancestor: %d %d => %d != %d", l, r, lr, answer)
+			}
+
+			if lr != answer {
+				t.Fatalf("Asymmetric ancestor: %d %d => %d != %d", l, r, rl, lr)
+			}
+		}
+	}
 }
 
 ///


### PR DESCRIPTION
This reflects two PRs on the spec repo:
* Using the epoch secret instead of the init secret to derive welcome secrets
* Using path secrets instead of a DirectPath in the welcome