### PR TITLE
Actually change state in tests

### DIFF
--- a/state_test.go
+++ b/state_test.go
@@ -253,14 +253,14 @@ func TestStateRemove(t *testing.T) {
 		assertNotError(t, err, "remove error")
 		stateTest.states = stateTest.states[:len(stateTest.states)-1]
 
-		for idx, state := range stateTest.states {
-			if idx == i {
-				state = *next
+		for j, state := range stateTest.states {
+			if j == i {
+				stateTest.states[j] = *next
 			} else {
 				state.handle(remove)
 				newState, err := state.handle(commit)
 				assertNotError(t, err, "remove processing error by others")
-				state = *newState
+				stateTest.states[j] = *newState
 			}
 		}
 

--- a/state_test.go
+++ b/state_test.go
@@ -211,24 +211,18 @@ func TestStateCipherNegotiation(t *testing.T) {
 func TestStateUpdate(t *testing.T) {
 	stateTest := setupGroup(t)
 	for i, state := range stateTest.states {
-		fmt.Printf("=== UPDATE(%d) ===\n", i)
 		leafSecret, _ := getRandomBytes(32)
 		update := state.update(leafSecret)
-		fmt.Printf("pid [%s]\n", state.proposalId(*update))
 		state.handle(update)
-		fmt.Printf("pid [%s]\n", state.proposalId(*update))
 		commit, _, next, err := state.commit(leafSecret)
 		assertNotError(t, err, "creator commit error")
 
 		for j, other := range stateTest.states {
-			fmt.Printf("=== UPDATE(%d -> %d) ===\n", i, j)
 			if j == i {
 				stateTest.states[j] = *next
 			} else {
-				fmt.Printf("pid [%s]\n", other.proposalId(*update))
 				_, err := other.handle(update)
 				assertNotError(t, err, "Update recipient proposal fail")
-				fmt.Printf("pid [%s]\n", other.proposalId(*update))
 
 				newState, err := other.handle(commit)
 				assertNotError(t, err, "Update recipient commit fail")
@@ -236,8 +230,7 @@ func TestStateUpdate(t *testing.T) {
 			}
 		}
 
-		for j, s := range stateTest.states {
-			fmt.Printf("=== UPDATE(%d =?= %d) ===\n", i, j)
+		for _, s := range stateTest.states {
 			assertTrue(t, stateTest.states[0].Equals(s), "states unequal")
 		}
 	}

--- a/state_test.go
+++ b/state_test.go
@@ -211,27 +211,34 @@ func TestStateCipherNegotiation(t *testing.T) {
 func TestStateUpdate(t *testing.T) {
 	stateTest := setupGroup(t)
 	for i, state := range stateTest.states {
+		fmt.Printf("=== UPDATE(%d) ===\n", i)
 		leafSecret, _ := getRandomBytes(32)
 		update := state.update(leafSecret)
+		fmt.Printf("pid [%s]\n", state.proposalId(*update))
 		state.handle(update)
+		fmt.Printf("pid [%s]\n", state.proposalId(*update))
 		commit, _, next, err := state.commit(leafSecret)
 		assertNotError(t, err, "creator commit error")
 
 		for j, other := range stateTest.states {
+			fmt.Printf("=== UPDATE(%d -> %d) ===\n", i, j)
 			if j == i {
-				state = *next
+				stateTest.states[j] = *next
 			} else {
+				fmt.Printf("pid [%s]\n", other.proposalId(*update))
 				_, err := other.handle(update)
 				assertNotError(t, err, "Update recipient proposal fail")
+				fmt.Printf("pid [%s]\n", other.proposalId(*update))
 
 				newState, err := other.handle(commit)
 				assertNotError(t, err, "Update recipient commit fail")
-				other = *newState
+				stateTest.states[j] = *newState
 			}
 		}
 
-		for _, s := range stateTest.states {
-			assertTrue(t, s.Equals(stateTest.states[0]), "states unequal")
+		for j, s := range stateTest.states {
+			fmt.Printf("=== UPDATE(%d =?= %d) ===\n", i, j)
+			assertTrue(t, stateTest.states[0].Equals(s), "states unequal")
 		}
 	}
 }


### PR DESCRIPTION
The existing tests of Update and Remove behavior do not actually store the updated/removed states, so as a result, it's as of each Update/Remove were being applied on the clean group as created.  Instead, they need to be applied to the group on top of each other.

Fixing this bug revealed several ways in which the State logic was incorrect.  Most notably, the transcript hash computations were wrong, using `digest.Sum()` incorrectly.