### PR TITLE
Segregate secret state

### DIFF
--- a/ratchet-tree.go
+++ b/ratchet-tree.go
@@ -302,6 +302,7 @@ func (t *RatchetTree) Encap(from leafIndex, context, leafSecret []byte) (*Direct
 		pathSecret := secrets[parent]
 		n = t.newNode(pathSecret)
 		t.Nodes[parent].Node = n
+		t.setPrivate(parent, *n.PrivateKey)
 
 		//update nodes on the direct path to share it with others
 		pathNode := DirectPathNode{PublicKey: t.getPublic(parent)}
@@ -570,16 +571,20 @@ func (t *RatchetTree) getPublic(n nodeIndex) HPKEPublicKey {
 }
 
 func (t *RatchetTree) setPrivate(n nodeIndex, priv HPKEPrivateKey) {
-	t.Nodes[n].Node.PrivateKey = &priv
+	t.Secrets.PrivateKeys[n] = priv
+	// t.Nodes[n].Node.PrivateKey = &priv
 	t.setPublic(n, priv.PublicKey)
 }
 
 func (t *RatchetTree) getPrivate(n nodeIndex) HPKEPrivateKey {
-	return *t.Nodes[n].Node.PrivateKey
+	return t.Secrets.PrivateKeys[n]
+	//return *t.Nodes[n].Node.PrivateKey
 }
 
 func (t *RatchetTree) hasPrivate(n nodeIndex) bool {
-	return t.Nodes[n].Node != nil && t.Nodes[n].Node.PrivateKey != nil
+	_, ok := t.Secrets.PrivateKeys[n]
+	return ok
+	//return t.Nodes[n].Node != nil && t.Nodes[n].Node.PrivateKey != nil
 }
 
 func (t *RatchetTree) rootIndex() nodeIndex {

--- a/ratchet-tree_test.go
+++ b/ratchet-tree_test.go
@@ -48,7 +48,7 @@ func (t *RatchetTree) checkInvariant(from leafIndex) bool {
 	dp = append(dp, t.rootIndex())
 	for _, nidx := range dp {
 		inDirPath[int(nidx)] = true
-		if t.Nodes[nidx].Node != nil && !t.Nodes[nidx].hasPrivate() {
+		if t.Nodes[nidx].Node != nil && !t.hasPrivate(nidx) {
 			return false
 		}
 	}
@@ -58,7 +58,7 @@ func (t *RatchetTree) checkInvariant(from leafIndex) bool {
 		if inDirPath[i] {
 			continue
 		}
-		if t.Nodes[i].hasPrivate() {
+		if t.hasPrivate(nodeIndex(i)) {
 			return false
 		}
 	}

--- a/secrets.go
+++ b/secrets.go
@@ -1,0 +1,25 @@
+package mls
+
+type TreeSecrets struct {
+	PrivateKeys map[nodeIndex]HPKEPrivateKey
+}
+
+func NewTreeSecrets() *TreeSecrets {
+	return &TreeSecrets{
+		PrivateKeys: map[nodeIndex]HPKEPrivateKey{},
+	}
+}
+
+func (ts *TreeSecrets) Clone() *TreeSecrets {
+	if ts == nil {
+		return NewTreeSecrets()
+	}
+
+	out := NewTreeSecrets()
+	for i, pk := range ts.PrivateKeys {
+		out.PrivateKeys[i] = pk
+	}
+	return out
+}
+
+// TODO MarshalTLS / UnmarshalTLS


### PR DESCRIPTION
This PR isolates the secret state for `RatchetTree` and `State` objects.  This is a first step toward the ultimate goal of being able to store and recall MLS state.