### PR TITLE
Marshal secrets

### DIFF
--- a/common.go
+++ b/common.go
@@ -4,6 +4,12 @@ import (
 	"fmt"
 )
 
+func dup(in []byte) []byte {
+	out := make([]byte, len(in))
+	copy(out, in)
+	return out
+}
+
 func validateEnum(v interface{}, known ...interface{}) error {
 	for _, kv := range known {
 		if v == kv {

--- a/key-schedule.go
+++ b/key-schedule.go
@@ -2,6 +2,8 @@ package mls
 
 import (
 	"fmt"
+
+	"github.com/bifurcation/mint/syntax"
 )
 
 type keyAndNonce struct {
@@ -9,14 +11,11 @@ type keyAndNonce struct {
 	Nonce []byte `tls:"head=1"`
 }
 
-func (k keyAndNonce) clone(suite CipherSuite) keyAndNonce {
-	cloned := keyAndNonce{
-		Key:   make([]byte, suite.constants().KeySize),
-		Nonce: make([]byte, suite.constants().NonceSize),
+func (k keyAndNonce) clone() keyAndNonce {
+	return keyAndNonce{
+		Key:   dup(k.Key),
+		Nonce: dup(k.Nonce),
 	}
-	copy(cloned.Key, k.Key)
-	copy(cloned.Nonce, k.Nonce)
-	return cloned
 }
 
 func zeroize(data []byte) {
@@ -32,12 +31,12 @@ func zeroize(data []byte) {
 type hashRatchet struct {
 	Suite          CipherSuite
 	Node           nodeIndex
-	NextSecret     []byte
+	NextSecret     []byte `tls:"head=1"`
 	NextGeneration uint32
-	Cache          map[uint32]keyAndNonce
-	KeySize        int
-	NonceSize      int
-	SecretSize     int
+	Cache          map[uint32]keyAndNonce `tls:"head=4"`
+	KeySize        uint32
+	NonceSize      uint32
+	SecretSize     uint32
 }
 
 func newHashRatchet(suite CipherSuite, node nodeIndex, baseSecret []byte) *hashRatchet {
@@ -47,16 +46,16 @@ func newHashRatchet(suite CipherSuite, node nodeIndex, baseSecret []byte) *hashR
 		NextSecret:     baseSecret,
 		NextGeneration: 0,
 		Cache:          map[uint32]keyAndNonce{},
-		KeySize:        suite.constants().KeySize,
-		NonceSize:      suite.constants().NonceSize,
-		SecretSize:     suite.constants().SecretSize,
+		KeySize:        uint32(suite.constants().KeySize),
+		NonceSize:      uint32(suite.constants().NonceSize),
+		SecretSize:     uint32(suite.constants().SecretSize),
 	}
 }
 
 func (hr *hashRatchet) Next() (uint32, keyAndNonce) {
-	key := hr.Suite.deriveAppSecret(hr.NextSecret, "app-key", hr.Node, hr.NextGeneration, hr.KeySize)
-	nonce := hr.Suite.deriveAppSecret(hr.NextSecret, "app-nonce", hr.Node, hr.NextGeneration, hr.NonceSize)
-	secret := hr.Suite.deriveAppSecret(hr.NextSecret, "app-secret", hr.Node, hr.NextGeneration, hr.SecretSize)
+	key := hr.Suite.deriveAppSecret(hr.NextSecret, "app-key", hr.Node, hr.NextGeneration, int(hr.KeySize))
+	nonce := hr.Suite.deriveAppSecret(hr.NextSecret, "app-nonce", hr.Node, hr.NextGeneration, int(hr.NonceSize))
+	secret := hr.Suite.deriveAppSecret(hr.NextSecret, "app-secret", hr.Node, hr.NextGeneration, int(hr.SecretSize))
 
 	generation := hr.NextGeneration
 
@@ -64,8 +63,9 @@ func (hr *hashRatchet) Next() (uint32, keyAndNonce) {
 	zeroize(hr.NextSecret)
 	hr.NextSecret = secret
 
-	hr.Cache[generation] = keyAndNonce{key, nonce}
-	return generation, hr.Cache[generation].clone(hr.Suite)
+	kn := keyAndNonce{key, nonce}
+	hr.Cache[generation] = kn
+	return generation, kn.clone()
 }
 
 func (hr *hashRatchet) Get(generation uint32) (keyAndNonce, error) {
@@ -106,7 +106,7 @@ type baseKeySource interface {
 
 type noFSBaseKeySource struct {
 	CipherSuite CipherSuite
-	RootSecret  []byte
+	RootSecret  []byte `tls:"head=1"`
 }
 
 func newNoFSBaseKeySource(suite CipherSuite, rootSecret []byte) *noFSBaseKeySource {
@@ -122,21 +122,35 @@ func (nfbks *noFSBaseKeySource) Get(sender leafIndex) []byte {
 	return nfbks.CipherSuite.deriveAppSecret(nfbks.RootSecret, "hs-secret", toNodeIndex(sender), 0, secretSize)
 }
 
+type Bytes1 []byte
+
+func (b Bytes1) MarshalTLS() ([]byte, error) {
+	return syntax.Marshal(struct {
+		Data []byte `tls:"head=1"`
+	}{b})
+}
+
+func (b Bytes1) UnarshalTLS(data []byte) (int, error) {
+	return syntax.Unmarshal(data, &struct {
+		Data []byte `tls:"head=1"`
+	}{b})
+}
+
 type treeBaseKeySource struct {
 	CipherSuite CipherSuite
-	SecretSize  int
+	SecretSize  uint32
 	Root        nodeIndex
 	Size        leafCount
-	Secrets     map[nodeIndex][]byte
+	Secrets     map[nodeIndex]Bytes1 `tls:"head=4"`
 }
 
 func newTreeBaseKeySource(suite CipherSuite, size leafCount, rootSecret []byte) *treeBaseKeySource {
 	tbks := &treeBaseKeySource{
 		CipherSuite: suite,
-		SecretSize:  suite.constants().SecretSize,
+		SecretSize:  uint32(suite.constants().SecretSize),
 		Root:        root(size),
 		Size:        size,
-		Secrets:     map[nodeIndex][]byte{},
+		Secrets:     map[nodeIndex]Bytes1{},
 	}
 
 	tbks.Secrets[tbks.Root] = rootSecret
@@ -172,18 +186,16 @@ func (tbks *treeBaseKeySource) Get(sender leafIndex) []byte {
 		R := right(node, tbks.Size)
 
 		secret := tbks.Secrets[node]
-		tbks.Secrets[L] = tbks.CipherSuite.deriveAppSecret(secret, "tree", L, 0, tbks.SecretSize)
-		tbks.Secrets[R] = tbks.CipherSuite.deriveAppSecret(secret, "tree", R, 0, tbks.SecretSize)
+		tbks.Secrets[L] = tbks.CipherSuite.deriveAppSecret(secret, "tree", L, 0, int(tbks.SecretSize))
+		tbks.Secrets[R] = tbks.CipherSuite.deriveAppSecret(secret, "tree", R, 0, int(tbks.SecretSize))
 		zeroize(tbks.Secrets[node])
 		delete(tbks.Secrets, node)
 	}
 
 	// Copy and return the leaf
-	out := make([]byte, tbks.SecretSize)
-	copy(out, tbks.Secrets[senderNode])
+	out := dup(tbks.Secrets[senderNode])
 	zeroize(tbks.Secrets[senderNode])
 	delete(tbks.Secrets, senderNode)
-
 	return out
 }
 
@@ -207,10 +219,6 @@ func (tbks *treeBaseKeySource) dump() {
 type groupKeySource struct {
 	Base     baseKeySource
 	Ratchets map[leafIndex]*hashRatchet
-}
-
-func newGroupKeySource(base baseKeySource) *groupKeySource {
-	return &groupKeySource{base, map[leafIndex]*hashRatchet{}}
 }
 
 func (gks groupKeySource) ratchet(sender leafIndex) *hashRatchet {
@@ -260,15 +268,22 @@ func groupInfoKeyAndNonce(suite CipherSuite, epochSecret []byte) keyAndNonce {
 
 type keyScheduleEpoch struct {
 	Suite             CipherSuite
-	EpochSecret       []byte
-	SenderDataSecret  []byte
-	SenderDataKey     []byte
-	HandshakeSecret   []byte
-	HandshakeKeys     *groupKeySource
-	ApplicationSecret []byte
-	ApplicationKeys   *groupKeySource
-	ConfirmationKey   []byte
-	InitSecret        []byte
+	EpochSecret       []byte `tls:"head=1"`
+	SenderDataSecret  []byte `tls:"head=1"`
+	SenderDataKey     []byte `tls:"head=1"`
+	HandshakeSecret   []byte `tls:"head=1"`
+	ApplicationSecret []byte `tls:"head=1"`
+	ConfirmationKey   []byte `tls:"head=1"`
+	InitSecret        []byte `tls:"head=1"`
+
+	HandshakeBaseKeys   *noFSBaseKeySource
+	ApplicationBaseKeys *treeBaseKeySource
+
+	HandshakeRatchets   map[leafIndex]*hashRatchet `tls:"head=4"`
+	ApplicationRatchets map[leafIndex]*hashRatchet `tls:"head=4"`
+
+	ApplicationKeys *groupKeySource `tls:"omit"`
+	HandshakeKeys   *groupKeySource `tls:"omit"`
 }
 
 func newKeyScheduleEpoch(suite CipherSuite, size leafCount, epochSecret, context []byte) keyScheduleEpoch {
@@ -282,18 +297,31 @@ func newKeyScheduleEpoch(suite CipherSuite, size leafCount, epochSecret, context
 	handshakeBaseKeys := newNoFSBaseKeySource(suite, handshakeSecret)
 	applicationBaseKeys := newTreeBaseKeySource(suite, size, applicationSecret)
 
-	return keyScheduleEpoch{
+	kse := keyScheduleEpoch{
 		Suite:             suite,
 		EpochSecret:       epochSecret,
 		SenderDataSecret:  senderDataSecret,
 		SenderDataKey:     senderDataKey,
 		HandshakeSecret:   handshakeSecret,
-		HandshakeKeys:     newGroupKeySource(handshakeBaseKeys),
 		ApplicationSecret: applicationSecret,
-		ApplicationKeys:   newGroupKeySource(applicationBaseKeys),
 		ConfirmationKey:   confirmationKey,
 		InitSecret:        initSecret,
+
+		HandshakeBaseKeys:   handshakeBaseKeys,
+		ApplicationBaseKeys: applicationBaseKeys,
+
+		HandshakeRatchets:   map[leafIndex]*hashRatchet{},
+		ApplicationRatchets: map[leafIndex]*hashRatchet{},
 	}
+
+	kse.enableKeySources()
+	return kse
+}
+
+// Wire up the key sources as logic on top of data owned by the epoch
+func (kse *keyScheduleEpoch) enableKeySources() {
+	kse.HandshakeKeys = &groupKeySource{kse.HandshakeBaseKeys, kse.HandshakeRatchets}
+	kse.ApplicationKeys = &groupKeySource{kse.ApplicationBaseKeys, kse.ApplicationRatchets}
 }
 
 func (kse *keyScheduleEpoch) Next(size leafCount, updateSecret, context []byte) keyScheduleEpoch {

--- a/key-schedule.go
+++ b/key-schedule.go
@@ -130,7 +130,7 @@ func (b Bytes1) MarshalTLS() ([]byte, error) {
 	}{b})
 }
 
-func (b Bytes1) UnarshalTLS(data []byte) (int, error) {
+func (b Bytes1) UnmarshalTLS(data []byte) (int, error) {
 	return syntax.Unmarshal(data, &struct {
 		Data []byte `tls:"head=1"`
 	}{b})

--- a/ratchet-tree.go
+++ b/ratchet-tree.go
@@ -138,7 +138,7 @@ func (n OptionalRatchetNode) Equals(o OptionalRatchetNode) bool {
 func (n OptionalRatchetNode) Clone() OptionalRatchetNode {
 	cloned := OptionalRatchetNode{
 		Node: nil,
-		Hash: make([]byte, len(n.Hash)),
+		Hash: dup(n.Hash),
 	}
 
 	if !n.blank() {
@@ -146,7 +146,6 @@ func (n OptionalRatchetNode) Clone() OptionalRatchetNode {
 		node = n.Node.Clone()
 		cloned.Node = &node
 	}
-	copy(cloned.Hash, n.Hash)
 	return cloned
 }
 
@@ -291,8 +290,7 @@ func (t *RatchetTree) PathSecrets(start nodeIndex, pathSecret []byte) map[nodeIn
 
 	curr := start
 	next := parent(curr, t.size())
-	secrets[curr] = make([]byte, len(pathSecret))
-	copy(secrets[curr], pathSecret)
+	secrets[curr] = dup(pathSecret)
 
 	for curr != t.rootIndex() {
 		secrets[next] = t.pathStep(secrets[curr])

--- a/ratchet-tree.go
+++ b/ratchet-tree.go
@@ -682,25 +682,20 @@ func (t RatchetTree) clone() *RatchetTree {
 }
 
 // Isolated getters and setters for secret state
-type TreeSecretsEntry struct {
-	Index      nodeIndex
-	PrivateKey HPKEPrivateKey
-}
-
 type TreeSecrets struct {
-	Entries []TreeSecretsEntry `tls:"head=4"`
+	PrivateKeys map[nodeIndex]HPKEPrivateKey `tls:"head=4"`
 }
 
 func (t *RatchetTree) SetSecrets(ts TreeSecrets) {
-	for i, entry := range ts.Entries {
-		priv := &ts.Entries[i].PrivateKey
-		t.Nodes[entry.Index].mergePrivate(priv)
+	for ix := range ts.PrivateKeys {
+		priv := ts.PrivateKeys[ix]
+		t.Nodes[ix].mergePrivate(&priv)
 	}
 }
 
 func (t RatchetTree) GetSecrets() TreeSecrets {
 	ts := TreeSecrets{
-		Entries: []TreeSecretsEntry{},
+		PrivateKeys: map[nodeIndex]HPKEPrivateKey{},
 	}
 
 	for i, maybeNode := range t.Nodes {
@@ -708,8 +703,7 @@ func (t RatchetTree) GetSecrets() TreeSecrets {
 			continue
 		}
 
-		entry := TreeSecretsEntry{nodeIndex(i), *maybeNode.Node.PrivateKey}
-		ts.Entries = append(ts.Entries, entry)
+		ts.PrivateKeys[nodeIndex(i)] = *maybeNode.Node.PrivateKey
 	}
 
 	return ts

--- a/ratchet-tree_test.go
+++ b/ratchet-tree_test.go
@@ -260,6 +260,37 @@ func TestRatchetTreeEncryptDecrypt(t *testing.T) {
 	}
 }
 
+func TestRatchetTreeSecrets(t *testing.T) {
+	suite := supportedSuites[0]
+
+	// Form a tree and split out the secret bits
+	tree := newTestRatchetTree(t, suite, allSecrets, allCreds)
+	secrets := tree.GetSecrets()
+
+	// Marshal the private and public parts
+	marshaledPub, err := syntax.Marshal(tree)
+	assertNotError(t, err, "Error in public marshal")
+
+	marshaledPriv, err := syntax.Marshal(secrets)
+	assertNotError(t, err, "Error in private marshal")
+
+	// Unmarshal the private and public parts
+	tree2 := newRatchetTree(suite)
+	secrets2 := TreeSecrets{}
+
+	_, err = syntax.Unmarshal(marshaledPub, tree2)
+	assertNotError(t, err, "Error in public unmarshal")
+
+	_, err = syntax.Unmarshal(marshaledPriv, &secrets2)
+	assertNotError(t, err, "Error in public unmarshal")
+
+	// Reassemble the tree
+	tree2.SetSecrets(secrets2)
+
+	// Compare public and private contents
+	assertDeepEquals(t, tree, tree2)
+}
+
 func TestRatchetTree_Clone(t *testing.T) {
 	tree := newTestRatchetTree(t, supportedSuites[0], allSecrets, allCreds)
 	assertTrue(t, tree.size() == 4, "size mismatch")

--- a/state.go
+++ b/state.go
@@ -856,11 +856,11 @@ func (s State) clone() *State {
 	// reference copies.
 	clone := &State{
 		CipherSuite:             s.CipherSuite,
-		GroupID:                 s.GroupID,
+		GroupID:                 dup(s.GroupID),
 		Epoch:                   s.Epoch,
 		Tree:                    *s.Tree.clone(),
 		ConfirmedTranscriptHash: nil,
-		InterimTranscriptHash:   make([]byte, len(s.InterimTranscriptHash)),
+		InterimTranscriptHash:   dup(s.InterimTranscriptHash),
 		Keys:                    s.Keys,
 		Index:                   s.Index,
 		IdentityPriv:            s.IdentityPriv,
@@ -868,8 +868,6 @@ func (s State) clone() *State {
 		UpdateSecrets:           s.UpdateSecrets,
 		PendingProposals:        make([]MLSPlaintext, len(s.PendingProposals)),
 	}
-	copy(clone.GroupID, s.GroupID)
-	copy(clone.InterimTranscriptHash, s.InterimTranscriptHash)
 	copy(clone.PendingProposals, s.PendingProposals)
 	return clone
 }

--- a/state.go
+++ b/state.go
@@ -96,7 +96,7 @@ func newJoinedState(ciks []ClientInitKey, welcome Welcome) (*State, error) {
 	var clientInitKey ClientInitKey
 	var encKeyPackage EncryptedKeyPackage
 	var found = false
-
+	suite := welcome.CipherSuite
 	// extract the keyPackage for init secret
 	for idx, cik := range ciks {
 		data, err := syntax.Marshal(cik)

--- a/state_test.go
+++ b/state_test.go
@@ -3,6 +3,8 @@ package mls
 import (
 	"fmt"
 	"testing"
+
+	"github.com/bifurcation/mint/syntax"
 )
 
 var (
@@ -114,6 +116,65 @@ func TestStateTwoPerson(t *testing.T) {
 	ct, err := first1.protect(testMessage)
 	assertNotError(t, err, "protect error")
 	pt, err := second1.unprotect(ct)
+	assertNotError(t, err, "unprotect failure")
+	assertByteEquals(t, pt, testMessage)
+}
+
+func TestStateMarshalUnmarshal(t *testing.T) {
+	// Create Alice and have her add Bob to a group
+	stateTest := setup(t)
+	alice0 := newEmptyState(groupId, suite, stateTest.initPrivs[0], stateTest.credentials[0])
+
+	add := alice0.add(stateTest.clientInitKeys[1])
+	_, err := alice0.handle(add)
+	assertNotError(t, err, "Initial add failed")
+
+	secret, _ := getRandomBytes(32)
+	_, welcome, alice1, err := alice0.commit(secret)
+	assertNotError(t, err, "Initial commit failed")
+
+	// TODO Marshal Alice
+	alice1pub, err := syntax.Marshal(alice1)
+	assertNotError(t, err, "Error marshaling Alice public values")
+
+	alice1priv, err := syntax.Marshal(alice1.GetSecrets())
+	assertNotError(t, err, "Error marshaling Alice private values")
+
+	// Initialize Bob generate an Update+Commit
+	bob1, err := newJoinedState([]ClientInitKey{stateTest.clientInitKeys[1]}, *welcome)
+	assertNotError(t, err, "state_test: state creation using Welcome failed")
+	assertTrue(t, alice1.Equals(*bob1), "State mismatch")
+
+	update := bob1.update(secret)
+	_, err = bob1.handle(update)
+	assertNotError(t, err, "Update failed at Bob")
+
+	commit, _, bob2, err := bob1.commit(secret)
+	assertNotError(t, err, "Update commit generation failed")
+
+	// TODO Recreate Alice
+	alice1a := new(State)
+	_, err = syntax.Unmarshal(alice1pub, alice1a)
+	assertNotError(t, err, "Error unmarshaling Alice public values")
+
+	alice1aPriv := StateSecrets{}
+	_, err = syntax.Unmarshal(alice1priv, &alice1aPriv)
+	assertNotError(t, err, "Error unmarshaling Alice private values")
+
+	alice1a.SetSecrets(alice1aPriv)
+
+	// Verify that Alice can process Bob's Update+Commit
+	_, err = alice1a.handle(update)
+	assertNotError(t, err, "Update failed at Alice")
+
+	alice2, err := alice1a.handle(commit)
+	assertNotError(t, err, "Update commit handling failed")
+
+	// Verify that Alice and Bob can exchange protected messages
+	/// Verify that they can exchange protected messages
+	ct, err := alice2.protect(testMessage)
+	assertNotError(t, err, "protect error")
+	pt, err := bob2.unprotect(ct)
 	assertNotError(t, err, "unprotect failure")
 	assertByteEquals(t, pt, testMessage)
 }

--- a/stream.go
+++ b/stream.go
@@ -31,11 +31,10 @@ func (s *WriteStream) Write(val interface{}) error {
 
 func (s *WriteStream) WriteAll(vals ...interface{}) error {
 	for _, val := range vals {
-		enc, err := syntax.Marshal(val)
+		err := s.Write(val)
 		if err != nil {
 			return err
 		}
-		s.buffer = append(s.buffer, enc...)
 	}
 	return nil
 }
@@ -65,6 +64,19 @@ func (s *ReadStream) Read(val interface{}) (int, error) {
 	}
 
 	s.cursor += read
+	return read, nil
+}
+
+func (s *ReadStream) ReadAll(vals ...interface{}) (int, error) {
+	read := 0
+	for _, val := range vals {
+		readHere, err := s.Read(val)
+		if err != nil {
+			return 0, err
+		}
+
+		read += readHere
+	}
 	return read, nil
 }
 

--- a/stream_test.go
+++ b/stream_test.go
@@ -39,6 +39,12 @@ func TestWriteStream(t *testing.T) {
 
 	encoded := w.Data()
 	assertByteEquals(t, encoded, streamTestInputs.encoded)
+
+	w2 := NewWriteStream()
+	err = w2.WriteAll(streamTestInputs.val1, streamTestInputs.val2,
+		streamTestInputs.val3, streamTestInputs.val4)
+	assertNotError(t, err, "Error in WriteAll")
+	assertByteEquals(t, w.Data(), w2.Data())
 }
 
 func TestReadStream(t *testing.T) {
@@ -67,4 +73,18 @@ func TestReadStream(t *testing.T) {
 	assertNotError(t, err, "Error reading from stream")
 	assertEquals(t, read, 4)
 	assertDeepEquals(t, val4, streamTestInputs.val4)
+
+	var val1a uint8
+	var val2a uint16
+	var val3a streamTestVec
+	var val4a uint32
+	r2 := NewReadStream(streamTestInputs.encoded)
+	read, err = r2.ReadAll(&val1a, &val2a, &val3a, &val4a)
+	assertNotError(t, err, "Error in ReadAll")
+	assertEquals(t, read, len(streamTestInputs.encoded))
+	assertDeepEquals(t, val1, val1a)
+	assertDeepEquals(t, val2, val2a)
+	assertDeepEquals(t, val3, val3a)
+	assertDeepEquals(t, val4, val4a)
+
 }


### PR DESCRIPTION
This PR enables RatchetTree and State objects to be marshaled and unmarshaled entirely.  Before RatchetTree objects would only marshal their public parts, and State objects had no provisions for marshaling at all.  Now marshaling the objects themselves will marshal the public parts, and a companion Secrets object will marshal the private parts.

Note that this depends on an upgrade to the [mint/syntax module](https://github.com/bifurcation/mint/pull/216) to support marshal/unmarshal of maps.