### PR TITLE
Some minor revisions to authentication code

### DIFF
--- a/credential.go
+++ b/credential.go
@@ -20,7 +20,7 @@ const (
 )
 
 func (ct CredentialType) ValidForTLS() error {
-	return validateEnum(ct, CredentialTypeBasic)
+	return validateEnum(ct, CredentialTypeBasic, CredentialTypeX509)
 }
 
 // struct {
@@ -228,7 +228,7 @@ func NewX509Credential(chain []*x509.Certificate, priv *SignaturePrivateKey) (*C
 		Chain: chain,
 	}
 
-	if !priv.PublicKey.Equals(*x509Credential.PublicKey()) {
+	if priv != nil && !priv.PublicKey.Equals(*x509Credential.PublicKey()) {
 		return nil, fmt.Errorf("Malformed credential: incorrect private key")
 	}
 

--- a/credential_test.go
+++ b/credential_test.go
@@ -120,7 +120,7 @@ func TestBasicCredential(t *testing.T) {
 	require.Nil(t, err)
 
 	cred2 := new(Credential)
-	_, err := syntax.Unmarshal(credData, cred2)
+	_, err = syntax.Unmarshal(credData, cred2)
 	require.Nil(t, err)
 }
 
@@ -137,7 +137,7 @@ func TestX509Credential(t *testing.T) {
 	require.Nil(t, err)
 
 	cred2 := new(Credential)
-	_, err := syntax.Unmarshal(credData, cred2)
+	_, err = syntax.Unmarshal(credData, cred2)
 	require.Nil(t, err)
 }
 

--- a/credential_test.go
+++ b/credential_test.go
@@ -115,6 +115,13 @@ func TestBasicCredential(t *testing.T) {
 	require.Equal(t, cred.Type(), CredentialTypeBasic)
 	require.Equal(t, cred.Scheme(), scheme)
 	require.Equal(t, *cred.PublicKey(), priv.PublicKey)
+
+	credData, err := syntax.Marshal(cred)
+	require.Nil(t, err)
+
+	cred2 := new(Credential)
+	_, err := syntax.Unmarshal(credData, cred2)
+	require.Nil(t, err)
 }
 
 func TestX509Credential(t *testing.T) {
@@ -125,6 +132,13 @@ func TestX509Credential(t *testing.T) {
 	require.Equal(t, cred.Type(), CredentialTypeX509)
 	require.Equal(t, cred.Scheme(), Ed25519)
 	require.NotNil(t, cred.PublicKey())
+
+	credData, err := syntax.Marshal(cred)
+	require.Nil(t, err)
+
+	cred2 := new(Credential)
+	_, err := syntax.Unmarshal(credData, cred2)
+	require.Nil(t, err)
 }
 
 func TestX509CredentialVerifyByName(t *testing.T) {


### PR DESCRIPTION
1. Allow for nil private keys in `NewX509Credential`
2. Allow TLS serialization by adding X509Credential to enum validation